### PR TITLE
Use local core for local development

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -6,6 +6,7 @@ target 'ios-showcase-template' do
   use_frameworks!
 
   if ENV['LOCAL']
+    pod 'AGSCore', :path => '../'
     pod 'AGSAuth', :path => '../'
     pod 'AGSPush', :path => '../'
   else


### PR DESCRIPTION
## Motivation

Noticed that without this, released core sdk is installed.