### PR TITLE
Show push registration error message

### DIFF
--- a/ios-showcase-template/AppDelegate.swift
+++ b/ios-showcase-template/AppDelegate.swift
@@ -113,7 +113,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication,
                      didFailToRegisterForRemoteNotificationsWithError error: Error) {
-        pushHelper.onRegistrationFailed(error)
+        self.appComponents?.failPushServiceRegistration(error)
     }
 
     func application(_ application: UIApplication, didReceiveRemoteNotification userInfo: [AnyHashable: Any], fetchCompletionHandler: @escaping (UIBackgroundFetchResult) -> Void) {

--- a/ios-showcase-template/di/AppComponents.swift
+++ b/ios-showcase-template/di/AppComponents.swift
@@ -13,6 +13,7 @@ import SwiftKeychainWrapper
 
 extension Notification.Name {
     static let serviceConfigMissing = Notification.Name("serviceConfigMissing")
+    static let pushServiceRegistrationFailure = Notification.Name("pushServiceRegistrationFailure")
 }
 
 enum ServiceType {
@@ -31,6 +32,7 @@ class AppComponents {
     let REALM_STORAGE_KEYCHAIN_ALIAS = "realm-db-keychain"
     var deviceTrustService: DeviceTrustService?
     var missingPushConfig = false
+    var failedPushRegistrationError: Error?
     
     init(appConfiguration: AppConfiguration) {
         self.appConfiguration = appConfiguration
@@ -74,6 +76,10 @@ class AppComponents {
         } catch {
             self.missingPushConfig = true
         }
+    }
+    
+    func failPushServiceRegistration(_ error: Error) {
+        self.failedPushRegistrationError = error
     }
     
     // Setup the Storage Service

--- a/ios-showcase-template/push/PushHelper.swift
+++ b/ios-showcase-template/push/PushHelper.swift
@@ -52,11 +52,4 @@ public class PushHelper {
             UIApplication.shared.registerUserNotificationSettings(settings)
         }
     }
-
-    /**
-        Called when Apple registration failed
-    */
-    public func onRegistrationFailed(_ error: Error) {
-        AgsCore.logger.error("Failure to register for notifications: \(error)")
-    }
 }

--- a/ios-showcase-template/root/RootViewController.swift
+++ b/ios-showcase-template/root/RootViewController.swift
@@ -89,7 +89,6 @@ class RootViewController: BaseViewController, DrawerMenuDelegate {
         MenuItem(MenuItemType.pushMessage, MENU_ITEM_TITLE_PUSH_MESSAGE,nil),
         
         MenuItem(MenuItemType.metrics, MENU_ITEM_TITLE_METRICS, "ic_metrics"),
-        // NOTE: These should be added back in when the metrics pages are created
         MenuItem(MenuItemType.metricsDocs, MENU_ITEM_TITLE_METRICS_DOCS, nil),
         MenuItem(MenuItemType.metricsProfile, MENU_ITEM_TITLE_METRICS_PROFILE, nil),
         MenuItem(MenuItemType.metricsTrust, MENU_ITEM_TITLE_METRICS_TRUST, nil)


### PR DESCRIPTION
Currently when push fails to register we create a log message but
do not show the end user of the app directly. This is important to
do as push messages do not ever successfully register on the iOS
simulator so the users will be left with a blank screen if they go
to the page on a simulator.

This adds a message saying that the push registration failed with
a details section that shows the message provided with the push
registration error.

![screen shot 2018-06-28 at 08 52 42](https://user-images.githubusercontent.com/8698527/42021196-e1ed408e-7ab1-11e8-82cf-802d93e5c212.png)
