### PR TITLE
fix: Fix invalid scheme definition

### DIFF
--- a/ios-showcase-template/Info.plist
+++ b/ios-showcase-template/Info.plist
@@ -25,7 +25,7 @@
 			<string>Editor</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>org.aerogear.ios-showcase-template:/callback</string>
+				<string>org.aerogear.ios-showcase-template</string>
 			</array>
 		</dict>
 	</array>


### PR DESCRIPTION
## Motivation

When building new application based on auth I found that both showcase and documentation define schemas improperly to the apple documentation for creation of schemes. Scheme that is defined should be ideally single alpha character word like : `meme`. Then application will react to the scheme and accept some path namespaces like `meme://callback`.
 
Scheme in showcase is defined as `org.aerogear.ios-showcase-template:/callback` which is going to run application using `org.aerogear.ios-showcase-template:/callback://`. 

Documentation should be changed as well to avoid confusion.

## Notes

Tested change with keycloak server.