### PR TITLE
Fix resume auth in app delegate

### DIFF
--- a/ios-showcase-template/AppDelegate.swift
+++ b/ios-showcase-template/AppDelegate.swift
@@ -16,7 +16,6 @@ import SwiftyJSON
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
-    var authService: AgsAuth?
     var pushHelper = PushHelper()
     var appComponents: AppComponents?
 
@@ -73,9 +72,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey: Any] = [:]) -> Bool {
         do {
-            return try authService!.resumeAuth(url: url as URL)
+            guard let resumeAuthSuccess = try self.appComponents?.resolveAuthService().resumeAuth(url: url as URL) else {
+                print("Could not resume auth process")
+                return false
+            }
+            return resumeAuthSuccess
         } catch AgsAuth.Errors.serviceNotConfigured {
-            print("Aerogear auth servie is not configured")
+            print("Aerogear auth service is not configured")
         } catch {
             fatalError("Unexpected error: \(error)")
         }


### PR DESCRIPTION
Currently it is possible for the auth service that's used to resume
the auth flow in app delegate to not be initialized.

This uses the app components helper to initialize the auth service
if it's not already.