### PR TITLE
Updated the showcase to use the new SDK version 2.0.0

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,6 +1,8 @@
 # Uncomment the next line to define a global platform for your project
 # platform :ios, '9.0'
 
+SdkVersion = '~> 2.0.0'
+
 target 'ios-showcase-template' do
   # Comment the next line if you're not using Swift and don't want to use dynamic frameworks
   use_frameworks!
@@ -12,9 +14,9 @@ target 'ios-showcase-template' do
     pod 'AGSPush', :path => ENV['LOCAL_DIR']
     pod 'AGSSecurity', :path => ENV['LOCAL_DIR']
   else
-    pod 'AGSAuth', '~> 1.0.0'
-    pod 'AGSPush', '~> 1.0.0'
-    pod 'AGSSecurity', '~> 1.0.0'
+    pod 'AGSAuth', SdkVersion
+    pod 'AGSPush', SdkVersion
+    pod 'AGSSecurity', SdkVersion
   end
 
   pod 'Alamofire', '~> 4.7'

--- a/ios-showcase-template.xcodeproj/project.pbxproj
+++ b/ios-showcase-template.xcodeproj/project.pbxproj
@@ -706,6 +706,7 @@
 				"${BUILT_PRODUCTS_DIR}/SCLAlertView/SCLAlertView.framework",
 				"${BUILT_PRODUCTS_DIR}/SnapKit/SnapKit.framework",
 				"${BUILT_PRODUCTS_DIR}/SwiftKeychainWrapper/SwiftKeychainWrapper.framework",
+				"${BUILT_PRODUCTS_DIR}/SwiftyJSON/SwiftyJSON.framework",
 				"${BUILT_PRODUCTS_DIR}/TrustKit/TrustKit.framework",
 				"${BUILT_PRODUCTS_DIR}/XCGLogger/XCGLogger.framework",
 			);
@@ -728,6 +729,7 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SCLAlertView.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SnapKit.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SwiftKeychainWrapper.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SwiftyJSON.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/TrustKit.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/XCGLogger.framework",
 			);

--- a/ios-showcase-template/deviceTrust/DeviceTrustInteractor.swift
+++ b/ios-showcase-template/deviceTrust/DeviceTrustInteractor.swift
@@ -17,17 +17,16 @@ protocol DeviceTrustInteractor: DeviceTrustListener {
 class DeviceTrustInteractorImpl: DeviceTrustInteractor {
     var deviceTrustService: DeviceTrustService
     var router: DeviceTrustRouter?
-
+    
     init(deviceTrustService: DeviceTrustService) {
         self.deviceTrustService = deviceTrustService
     }
-
+    
     /**
      - Perform the device trust checks in the device trust service.
-
      - Returns SecurityCheckResult: A list of security check results
      */
-    func performTrustChecks() -> [SecurityCheckResult] {
+    func performTrustChecks() -> [DeviceCheckResult] {
         return self.deviceTrustService.performTrustChecks()
     }
 }

--- a/ios-showcase-template/services/DeviceTrustService.swift
+++ b/ios-showcase-template/services/DeviceTrustService.swift
@@ -4,12 +4,12 @@ import Foundation
 import LocalAuthentication
 
 protocol DeviceTrustService {
-    func performTrustChecks() -> [SecurityCheckResult]
+    func performTrustChecks() -> [DeviceCheckResult]
 }
 
 class iosDeviceTrustService: DeviceTrustService {
     var security: AgsSecurity
-    var detections: [SecurityCheckResult]
+    var detections: [DeviceCheckResult]
 
     /**
      - Initilise the iOS Device Trust Service
@@ -22,9 +22,9 @@ class iosDeviceTrustService: DeviceTrustService {
     /**
      - Perform the Device Trust Checks
 
-     - Returns: A list of SecurityCheckResult objects
+     - Returns: A list of DeviceCheckResult objects
      */
-    func performTrustChecks() -> [SecurityCheckResult] {
+    func performTrustChecks() -> [DeviceCheckResult] {
         self.detections = []
         if #available(iOS 9.0, *) {
             self.detections.append(detectDeviceLock())
@@ -41,10 +41,10 @@ class iosDeviceTrustService: DeviceTrustService {
     /**
      - Perform all security checks and publish the results
      
-     - Returns: A SecurityCheckResult array
+     - Returns: A DeviceCheckResult array
      */
-    fileprivate func detectAll() -> [SecurityCheckResult] {
-        let checks : [SecurityCheck] = [DeviceLockCheck(), NonDebugCheck(), NonEmulatorCheck(), NonJailbrokenCheck()]
+    fileprivate func detectAll() -> [DeviceCheckResult] {
+        let checks : [DeviceCheck] = [DeviceLockEnabledCheck(), DebuggerAttachedCheck(), IsEmulatorCheck(), JailbrokenDeviceCheck()]
         return self.security.checkManyAndPublishMetric(checks)
     }
     
@@ -52,10 +52,10 @@ class iosDeviceTrustService: DeviceTrustService {
     /**
      - Check if a lock screen is set on the device. (iOS 9 or higher).
 
-     - Returns: A SecurityCheckResult object.
+     - Returns: A DeviceCheckResult object.
      */
-    fileprivate func detectDeviceLock() -> SecurityCheckResult {
-        return self.security.checkAndPublishMetric(DeviceLockCheck())
+    fileprivate func detectDeviceLock() -> DeviceCheckResult {
+        return self.security.checkAndPublishMetric(DeviceLockEnabledCheck())
     }
     // end::detectDeviceLock[]
 
@@ -63,11 +63,11 @@ class iosDeviceTrustService: DeviceTrustService {
     /**
      - Check if the device running the application is jailbroken.
 
-     - Returns: A SecurityCheckResult object.
+     - Returns: A DeviceCheckResult object.
      */
 
-    fileprivate func detectJailbreak() -> SecurityCheckResult {
-        return self.security.checkAndPublishMetric(NonJailbrokenCheck())
+    fileprivate func detectJailbreak() -> DeviceCheckResult {
+        return self.security.checkAndPublishMetric(JailbrokenDeviceCheck())
     }
 
     // end::detectJailbreak[]
@@ -76,10 +76,10 @@ class iosDeviceTrustService: DeviceTrustService {
     /**
      - Check if the device running the application is jailbroken.
 
-     - Returns: A SecurityCheckResult object.
+     - Returns: A DeviceCheckResult object.
      */
-    fileprivate func detectDebugabble() -> SecurityCheckResult {
-        return self.security.checkAndPublishMetric(NonDebugCheck())
+    fileprivate func detectDebugabble() -> DeviceCheckResult {
+        return self.security.checkAndPublishMetric(DebuggerAttachedCheck())
     }
 
     // end::detectDebugabble[]
@@ -88,10 +88,10 @@ class iosDeviceTrustService: DeviceTrustService {
     /**
      - Check if the application is running in an emulator.
 
-     - Returns: A SecurityCheckResult object.
+     - Returns: A DeviceCheckResult object.
      */
-    fileprivate func detectEmulator() -> SecurityCheckResult {
-        return self.security.checkAndPublishMetric(NonEmulatorCheck())
+    fileprivate func detectEmulator() -> DeviceCheckResult {
+        return self.security.checkAndPublishMetric(IsEmulatorCheck())
     }
 
     // end::detectEmulator[]

--- a/ios-showcase-templateTests/deviceTrust/DeviceTrustViewControllerTest.swift
+++ b/ios-showcase-templateTests/deviceTrust/DeviceTrustViewControllerTest.swift
@@ -10,8 +10,8 @@ import XCTest
 import AGSSecurity
 
 class FakeDeviceTrustListener: DeviceTrustListener {
-    func performTrustChecks() -> [SecurityCheckResult] {
-        let result = SecurityCheckResult("test", false)
+    func performTrustChecks() -> [DeviceCheckResult] {
+        let result = DeviceCheckResult("test", false)
         return [result]
     }
 }
@@ -25,6 +25,7 @@ class DeviceTrustViewControllerTest: XCTestCase {
         let mainStoryboard = UIStoryboard(name: "Main", bundle: nil)
         deviceTrustVCToTest = mainStoryboard.instantiateViewController(withIdentifier: "DeviceTrustViewController") as! DeviceTrustViewController
         deviceTrustVCToTest.deviceTrustListener = FakeDeviceTrustListener()
+        deviceTrustVCToTest.CHECKS_RESULT = ["test": [true: "test", false: "test", DeviceTrustViewController.SECURE_WHEN_FALSE: false]];
         UIApplication.shared.keyWindow!.rootViewController = deviceTrustVCToTest
         _ = deviceTrustVCToTest.view
     }


### PR DESCRIPTION
# Motivation
Issue: https://issues.jboss.org/browse/AEROGEAR-7744

Due to changes to the SDK API syntax and semantics, showcase app needed to be updated.
Now it uses the new `DeviceCheck`s (in place of the old `SecurityCheck`s) and adds logic to decide when the result of the check is `secure` or not (previously a `true` result had the meaning of `secure`).